### PR TITLE
add readonly as attribute to pikaday-input

### DIFF
--- a/addon/components/pikaday-input.js
+++ b/addon/components/pikaday-input.js
@@ -4,6 +4,7 @@ import Ember from 'ember';
 
 export default Ember.Component.extend({
   tagName: 'input',
+  attributeBindings: ['readonly'],
 
   setupPikaday: function() {
     var that = this;

--- a/tests/unit/components/pikaday-input-test.js
+++ b/tests/unit/components/pikaday-input-test.js
@@ -10,6 +10,15 @@ test('is an input tag', function() {
   this.subject().teardownPikaday();
 });
 
+test('the input tag has the readonly attribute if it has been set on the component', function() {
+  var component = this.subject();
+  component.set('readonly', true);
+
+  ok(this.$().is('[readonly]'));
+
+  this.subject().teardownPikaday();
+});
+
 test('clicking the input opens the pikaday dialog', function() {
   var $input = this.append();
 


### PR DESCRIPTION
It would be great to have 'readonly' support for mobile devices:

```javascript
{{pikaday-input  readonly='readonly'}}
```