### PR TITLE
Add support for specifying yearRange

### DIFF
--- a/addon/components/pikaday-input.js
+++ b/addon/components/pikaday-input.js
@@ -17,7 +17,8 @@ export default Ember.Component.extend({
         });
       },
       firstDay: 1,
-      format: this.get('format') || 'DD.MM.YYYY'
+      format: this.get('format') || 'DD.MM.YYYY',
+      yearRange: this.get('yearRange') || 10
     };
 
     if (this.get('i18n')) {


### PR DESCRIPTION
In order to change the year range when selecting a year, the yearRange needs to
be configurable. This updates the pikaday-input component to use the
yearRange, if specified. Default to 10, the pikaday default, if yearRange has not
been specified.