### PR TITLE
Add UTC as an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,19 @@ The `readonly` attribute is supported as binding so you can make the input reado
 </label>
 ```
 
+## Use UTC timezone
+
+If you do not use UTC time zone, ember-pikaday will return date formatted in your local time zone. It may lead to strange situations when you set proper date, but afterwards use some kind of date-format helper that converts your date to UTC. In additive time-zones (e.g. +1) it will end up with yesterday date. If you need to always get UTC timezone dates pass the `useUTC=true` option to the component. The result will be JavaScript `Date Object` with UTC timezone.
+
+```handlebars
+<label>
+  Start date:
+  {{pikaday-input value=startsAt useUTC=true}}
+</label>
+```
+
+However, remember that setting the value from your application (not by the user) will not automatically convert set date to UTC timezone. Therefore, if you `#set` the date formatted in local time zone outside from the component, ember-pikaday will show correct date but still in defined by you timezone.
+
 ## Localization
 
 Localizing the datepicker is possible in two steps. To localize the output of the datepicker, this is the formatted string visible in the input field, you simply add the correct Moment.js locale file to your applications `Brocfile.js`.

--- a/addon/components/pikaday-input.js
+++ b/addon/components/pikaday-input.js
@@ -2,6 +2,8 @@
 
 import Ember from 'ember';
 
+var moment = window.moment;
+
 export default Ember.Component.extend({
   tagName: 'input',
   attributeBindings: ['readonly'],
@@ -35,7 +37,9 @@ export default Ember.Component.extend({
   }.on('willDestroyElement'),
 
   userSelectedDate: function() {
-    this.set('value', this.get('pikaday').getDate());
+    var selectedDate = this.get('pikaday').getDate();
+    var utcDate = moment.utc([selectedDate.getFullYear(), selectedDate.getMonth(), selectedDate.getDate()]).toDate();
+    this.set('value', utcDate);
   },
 
   setDate: function() {

--- a/addon/components/pikaday-input.js
+++ b/addon/components/pikaday-input.js
@@ -38,8 +38,11 @@ export default Ember.Component.extend({
 
   userSelectedDate: function() {
     var selectedDate = this.get('pikaday').getDate();
-    var utcDate = moment.utc([selectedDate.getFullYear(), selectedDate.getMonth(), selectedDate.getDate()]).toDate();
-    this.set('value', utcDate);
+    if (this.get('utc'))
+    {
+      selectedDate = moment.utc([selectedDate.getFullYear(), selectedDate.getMonth(), selectedDate.getDate()]).toDate();
+    }
+    this.set('value', selectedDate);
   },
 
   setDate: function() {

--- a/addon/components/pikaday-input.js
+++ b/addon/components/pikaday-input.js
@@ -38,8 +38,7 @@ export default Ember.Component.extend({
 
   userSelectedDate: function() {
     var selectedDate = this.get('pikaday').getDate();
-    if (this.get('utc'))
-    {
+    if (this.get('useUTC')) {
       selectedDate = moment.utc([selectedDate.getFullYear(), selectedDate.getMonth(), selectedDate.getDate()]).toDate();
     }
     this.set('value', selectedDate);

--- a/tests/unit/components/pikaday-input-test.js
+++ b/tests/unit/components/pikaday-input-test.js
@@ -84,7 +84,7 @@ test('default i18n configuration of Pikaday can be changed', function(assert) {
 
 test('if utc is set the date returned from pikaday should be in UTC format', function(assert) {
   var component = this.subject();
-  component.set('utc', true);
+  component.set('useUTC', true);
   var $input = this.render();
   var interactor = openDatepicker($input);
 

--- a/tests/unit/components/pikaday-input-test.js
+++ b/tests/unit/components/pikaday-input-test.js
@@ -81,3 +81,18 @@ test('default i18n configuration of Pikaday can be changed', function(assert) {
 
   assert.equal($('.pika-select-month option:selected').text(), 'März');
 });
+
+test('if utc is set the date returned from pikaday should be in UTC format', function(assert) {
+  var component = this.subject();
+  component.set('utc', true);
+  var $input = this.render();
+  var interactor = openDatepicker($input);
+
+  interactor.selectDate(new Date(2013, 3, 28));
+
+  var date = this.subject().get('value');
+
+  assert.equal(date.getUTCFullYear(), 2013);
+  assert.equal(date.getUTCMonth(), 3);
+  assert.equal(date.getUTCDate(), 28);
+});


### PR DESCRIPTION
Selected date via Pikaday is returned in local timezone. I bumped into situation where everywhere in application we parse dates to UTC format as it's used across variety of timezones. It made an issue that dates selected on additive time zones were parsed as yesterday (subtracting hours from 00:00 at selected date).

I propose a simple solution to pass `utc` option to ember-pikaday that will take care to format the date to UTC before setting in on `value` property. I provide test for that feature in advance.

The feature uses `momentjs`, but as it is already in `bower` I do not see any disadvantages of such solution.