### PR TITLE
Add support for specifying the yearRange

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,23 @@ You can also change the default format from `DD.MM.YYYY` to any format string su
 </label>
 ```
 
+You can change the `yearRange`. It defaults to 10. the `yearRange` can be a
+single number or two comma separated years.
+
+```handlebars
+<label>
+  Start date:
+  {{pikaday-input value=startsAt yearRange="4"}}
+</label>
+```
+
+```handlebars
+<label>
+  Start date:
+  {{pikaday-input value=startsAt yearRange="2004,2008"}}
+</label>
+```
+
 The `readonly` attribute is supported as binding so you can make the input readonly for mobile or other usecases.
 
 ```handlebars

--- a/README.md
+++ b/README.md
@@ -49,6 +49,16 @@ single number or two comma separated years.
 </label>
 ```
 
+If the second year of the comma separated years is set to `currentYear`, it sets
+the maximum selectable year to the current year.
+
+```handlebars
+<label>
+  Start date:
+  {{pikaday-input value=startsAt yearRange="2004,currentYear"}}
+</label>
+```
+
 The `readonly` attribute is supported as binding so you can make the input readonly for mobile or other usecases.
 
 ```handlebars

--- a/addon/components/pikaday-input.js
+++ b/addon/components/pikaday-input.js
@@ -48,7 +48,13 @@ export default Ember.Component.extend({
 
     if (yearRange) {
       if (yearRange.indexOf(',') > -1) {
-        return yearRange.split(',');
+        var yearArray =  yearRange.split(',');
+
+        if (yearArray[1] === 'currentYear') {
+          yearArray[1] = new Date().getFullYear();
+        }
+
+        return yearArray;
       } else {
         return yearRange;
       }

--- a/addon/components/pikaday-input.js
+++ b/addon/components/pikaday-input.js
@@ -17,7 +17,8 @@ export default Ember.Component.extend({
         });
       },
       firstDay: 1,
-      format: this.get('format') || 'DD.MM.YYYY'
+      format: this.get('format') || 'DD.MM.YYYY',
+      yearRange: that.determineYearRange()
     };
 
     if (this.get('i18n')) {
@@ -40,5 +41,19 @@ export default Ember.Component.extend({
 
   setDate: function() {
     this.get('pikaday').setDate(this.get('value'), true);
-  }.observes('value')
+  }.observes('value'),
+
+  determineYearRange: function() {
+    var yearRange = this.get('yearRange');
+
+    if (yearRange) {
+      if (yearRange.indexOf(',') > -1) {
+        return yearRange.split(',');
+      } else {
+        return yearRange;
+      }
+    } else {
+      return 10;
+    }
+  }
 });

--- a/addon/helpers/pikaday.js
+++ b/addon/helpers/pikaday.js
@@ -31,6 +31,12 @@ var PikadayInteractor = {
   },
   selectedYear: function() {
     return $(this.selectorForYearSelect + ' option:selected').val();
+  },
+  minimumYear: function() {
+    return $(this.selectorForYearSelect).children().first().val();
+  },
+  maximumYear: function() {
+    return $(this.selectorForYearSelect).children().last().val();
   }
 };
 

--- a/tests/unit/components/pikaday-input-test.js
+++ b/tests/unit/components/pikaday-input-test.js
@@ -91,6 +91,16 @@ test('yearRange of the input can be set with comma separated years', function(as
   assert.equal(interactor.maximumYear(), 2006);
 });
 
+test('yearRange of the input with comma separated years supports currentYear as max', function(assert) {
+  this.subject().set('yearRange', '1900,currentYear');
+  var $input = this.render();
+  var interactor = openDatepicker($input);
+  var currentYear = new Date().getFullYear();
+
+  assert.equal(interactor.minimumYear(), 1900);
+  assert.equal(interactor.maximumYear(), currentYear);
+});
+
 test('default i18n configuration of Pikaday can be changed', function(assert) {
   var component = this.subject({
     i18n: {

--- a/tests/unit/components/pikaday-input-test.js
+++ b/tests/unit/components/pikaday-input-test.js
@@ -63,6 +63,34 @@ test('format of the input is changeable', function(assert) {
   assert.equal($input.val(), '2010.10.08');
 });
 
+test('yearRange of the input defaults to 10', function(assert) {
+  var $input = this.render();
+  var interactor = openDatepicker($input);
+  var currentYear = new Date().getFullYear();
+
+  assert.equal(interactor.minimumYear(), currentYear - 10);
+  assert.equal(interactor.maximumYear(), currentYear + 10);
+});
+
+test('yearRange of the input can be set with a range', function(assert) {
+  this.subject().set('yearRange', '4');
+  var $input = this.render();
+  var interactor = openDatepicker($input);
+  var currentYear = new Date().getFullYear();
+
+  assert.equal(interactor.minimumYear(), currentYear - 4);
+  assert.equal(interactor.maximumYear(), currentYear + 4);
+});
+
+test('yearRange of the input can be set with comma separated years', function(assert) {
+  this.subject().set('yearRange', '1900,2006');
+  var $input = this.render();
+  var interactor = openDatepicker($input);
+
+  assert.equal(interactor.minimumYear(), 1900);
+  assert.equal(interactor.maximumYear(), 2006);
+});
+
 test('default i18n configuration of Pikaday can be changed', function(assert) {
   var component = this.subject({
     i18n: {


### PR DESCRIPTION
Follow up to #11. This adds support for `yearRange` to the component. This contains tests and documentation, as well as handling three different scenarios:

- specifying a number as the min and max range from the current year - `yearRange='4'`
- specifying a comma separated value of years - `yearRange='1900,2000'`
- specifying a comma separated value of years with 0 as the second year, signifying the current year - `yearRange='1900,0'`.

The third scenario is one that would be very useful to me, but I believe adds some logic outside of what Pikaday provides. Let me know if you do not think it is appropriate!