### PR TITLE
Make it work with Pikaday master

### DIFF
--- a/addon/helpers/pikaday.js
+++ b/addon/helpers/pikaday.js
@@ -21,7 +21,7 @@ var PikadayInteractor = {
     $(this.selectorForMonthSelect).val(month);
     triggerNativeEvent($(this.selectorForMonthSelect)[0], 'change');
 
-    triggerNativeEvent($('td[data-day="' + day + '"] button')[0], 'mousedown');
+    triggerNativeEvent($('td[data-day="' + day + '"] button')[0], 'ontouchend' in document ? 'ontouchend' : 'mousedown');
   },
   selectedDay: function() {
     return $('.pika-single td.is-selected button').html();

--- a/bower.json
+++ b/bower.json
@@ -12,10 +12,7 @@
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.0.2",
     "ember-qunit-notifications": "0.0.5",
     "qunit": "~1.17.1",
-    "ember-qunit": "rwjblue/ember-qunit-builds#0.2.4"
-  },
-  "devDependencies": {
-    "pikaday": "~1.2.0",
+    "pikaday": "dbushell/Pikaday#master",
     "moment": "~2.8.3"
   }
 }


### PR DESCRIPTION
Pikaday registers a handler for the `'ontouchend'` if that's available while ember-pikaday's `selectDate` helper will always trigger a `'mousedown'` event which Pikaday will never catch…

Of course the master dependency in `bower.json` is just for now to illustrate the fix.

This will eventually fix #16.