### PR TITLE
Update readme for newer versions of ember-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ ember-pikaday is an addon that can be installed with Ember CLI. It gives you a d
 
 ```bash
 cd your-project-directory
-ember install:addon ember-pikaday
+ember install ember-pikaday
 ```
 
 ## Usage


### PR DESCRIPTION
Apparently `ember install:addon` is a thing of the past. I just tried this on version 0.2.3 and that command didn't exist. It's just `ember install addon-name` now.