### PR TITLE
fix disabled

### DIFF
--- a/addon/components/pikaday-input.js
+++ b/addon/components/pikaday-input.js
@@ -81,8 +81,8 @@ export default Ember.Component.extend({
     }
   },
 
-  autoHideOnDisabled: Ember.observer('disabled', function () {
-    if (this.get('disabled')) {
+  autoHideOnDisabled: Ember.observer('disabled', 'pikaday', function () {
+    if (this.get('disabled') && this.get('pikaday')) {
       this.get('pikaday').hide();
     }
   })


### PR DESCRIPTION
When I set disabled to true, it was trying to hide the pikaday element before the pikaday element existed.

![screenshot 2015-07-06 12 32 32](https://cloud.githubusercontent.com/assets/839123/8528843/912eaa46-23db-11e5-9704-8a1c65165f57.png)

Now it hides the pikaday element after it is created.