### PR TITLE
Add type='text' to the input tag so that it is formatted with Zurb

### DIFF
--- a/addon/components/pikaday-input.js
+++ b/addon/components/pikaday-input.js
@@ -4,7 +4,8 @@ import Ember from 'ember';
 
 export default Ember.Component.extend({
   tagName: 'input',
-  attributeBindings: ['readonly', 'disabled', 'placeholder'],
+  attributeBindings: ['readonly', 'disabled', 'placeholder', 'type'],
+  type: 'text',
 
   setupPikaday: Ember.on('didInsertElement', function() {
     var that = this;


### PR DESCRIPTION
When using this addon with Zurb Foundation, the input field is not styled correctly because it lacks "type" attribute. This should fix it.