### PR TITLE
Adds support for firstDay option

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,20 @@ If the datepicker is shown to the user and it gets disabled it will close the da
 </label>
 ```
 
+The `firstDay` attribute is supported as a binding so you can set the first day of the calendar week.
+Defaults to Monday.
+
+* 0 = Sunday
+* 1 = Monday
+* etc...
+
+```handlebars
+<label>
+  Due date:
+  {{pikaday-input value=dueAt firstDay=0}}
+</label>
+```
+
 ## Return dates in UTC time zone
 
 The date returned by ember-pikaday is in your local time zone due to the JavaScript default behaviour of `new Date()`. This can lead to problems when your application converts the date to UTC. In additive time zones (e.g. +0010) the resulting converted date could be yesterdays date. You can force the component to return a date with the UTC time zone by passing `useUTC=true` to it.

--- a/addon/components/pikaday-input.js
+++ b/addon/components/pikaday-input.js
@@ -8,6 +8,7 @@ export default Ember.Component.extend({
 
   setupPikaday: Ember.on('didInsertElement', function() {
     var that = this;
+    var firstDay = this.get('firstDay');
 
     var options = {
       field: this.$()[0],
@@ -15,7 +16,7 @@ export default Ember.Component.extend({
       onClose: Ember.run.bind(this, this.onPikadayClose),
       onSelect: Ember.run.bind(this, this.onPikadaySelect),
       onDraw: Ember.run.bind(this, this.onPikadayRedraw),
-      firstDay: 1,
+      firstDay: (typeof firstDay !== 'undefined') ? parseInt(firstDay, 10) : 1,
       format: this.get('format') || 'DD.MM.YYYY',
       yearRange: that.determineYearRange(),
       theme: this.get('theme') || null

--- a/tests/unit/components/pikaday-input-test.js
+++ b/tests/unit/components/pikaday-input-test.js
@@ -184,3 +184,23 @@ test('the disabled attribute of the component is well linked with the input attr
   assert.ok(this.$().is('[disabled]'), 'disabled should now be set');
   assert.ok($('.pika-single').hasClass('is-hidden', 'disabled and pika-single should be hidden automatically'));
 });
+
+test('firstDay defaults to Monday (1)', function (assert) {
+  var component = this.subject();
+  this.render();
+  openDatepicker(this.$());
+
+  var firstDay = $('.pika-single .pika-table tr th:first-child').text();
+
+  assert.equal(firstDay, 'Mon', 'First day should be Monday');
+});
+
+test('firstDay option overrides the default first day value', function (assert) {
+  var component = this.subject({ firstDay: 0 });
+  this.render();
+  openDatepicker(this.$());
+
+  var firstDay = $('.pika-single .pika-table tr th:first-child').text();
+
+  assert.equal(firstDay, 'Sun', 'First day should be Sunday');
+});


### PR DESCRIPTION
I'm not totally sure how to test this since it's just passing an option along to Pikaday and I didn't want to test Pikaday behavior.

######

The firstDay option lets you set the first day of the calendar.

    0 = Sunday
    1 = Monday
    etc...