### PR TITLE
Fix: test-helpers only work with one picker

### DIFF
--- a/addon/helpers/pikaday.js
+++ b/addon/helpers/pikaday.js
@@ -9,8 +9,8 @@ var openDatepicker = function(element) {
 };
 
 var PikadayInteractor = {
-  selectorForMonthSelect: '.pika-select-month',
-  selectorForYearSelect: '.pika-select-year',
+  selectorForMonthSelect: '.pika-select-month:visible',
+  selectorForYearSelect: '.pika-select-year:visible',
   selectDate: function(date) {
     var day = date.getDate();
     var month = date.getMonth();
@@ -22,7 +22,7 @@ var PikadayInteractor = {
     $(this.selectorForMonthSelect).val(month);
     triggerNativeEvent($(this.selectorForMonthSelect)[0], 'change');
 
-    triggerNativeEvent($('td[data-day="' + day + '"] button')[0], selectEvent);
+    triggerNativeEvent($('td[data-day="' + day + '"] button:visible')[0], selectEvent);
   },
   selectedDay: function() {
     return $('.pika-single td.is-selected button').html();


### PR DESCRIPTION
Because the test-helpers is not scoped to visible pickers and pikaday creates multiple pickers when creating multiple datepickers the test-helper did not work as expected when multiple pickers were present on the page (only the first one was selecting dates).

I am not sure how we should test this. We could create an acceptance test for that. Not sure if that is that useful though.