### PR TITLE
Add 'size' to the list of attribute bindings

### DIFF
--- a/addon/components/pikaday-input.js
+++ b/addon/components/pikaday-input.js
@@ -4,7 +4,7 @@ import Ember from 'ember';
 
 export default Ember.Component.extend({
   tagName: 'input',
-  attributeBindings: ['readonly', 'disabled', 'placeholder', 'type', 'name'],
+  attributeBindings: ['readonly', 'disabled', 'placeholder', 'type', 'name', 'size'],
   type: 'text',
 
   setupPikaday: Ember.on('didInsertElement', function() {


### PR DESCRIPTION
Sometimes I want my pikaday input to be size=10, other times, the default size is fine. This PR lets the user specify how large the pikaday input will be when rendered.

Usage: 

`{{pikaday-input value='12/12/2012' size='10'}}`