### PR TITLE
Make ember-pikaday compatible with ember-moment localization

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,9 +159,8 @@ To localize the datepicker itself, this is the popup you see after clicking the 
 ```js
 // app/initializers/setup-pikaday-i18n.js
 
-/* globals moment */
-
 import Ember from 'ember';
+import moment from 'moment';
 
 export default {
   name: 'setup-pikaday-i18n',

--- a/addon/components/pikaday-input.js
+++ b/addon/components/pikaday-input.js
@@ -1,6 +1,7 @@
-/* globals Pikaday, moment */
+/* globals Pikaday */
 
 import Ember from 'ember';
+import moment from 'moment';
 
 export default Ember.Component.extend({
   tagName: 'input',

--- a/blueprints/ember-pikaday/index.js
+++ b/blueprints/ember-pikaday/index.js
@@ -5,7 +5,7 @@ module.exports = {
     var that = this;
 
     return this.addBowerPackageToProject('pikaday').then(function() {
-        return that.addBowerPackageToProject('moment');
+      return that.addAddonToProject('ember-cli-moment-shim', '0.6.2');
     });
   }
 };

--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
     "ember-qunit": "0.4.9",
     "ember-qunit-notifications": "0.0.7",
     "pikaday": "~1.3.3",
-    "moment": "~2.8.3",
+    "moment": ">= 2.8.0",
     "ember-resolver": "~0.1.18",
     "jquery": "^1.11.3",
     "loader.js": "ember-cli/loader.js#3.2.1",

--- a/index.js
+++ b/index.js
@@ -7,7 +7,6 @@ module.exports = {
   included: function(app) {
     this._super.included(app);
 
-    app.import(app.bowerDirectory + '/moment/moment.js');
     app.import(app.bowerDirectory + '/pikaday/pikaday.js');
     app.import(app.bowerDirectory + '/pikaday/css/pikaday.css');
   }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "ember-cli-htmlbars-inline-precompile": "^0.2.0",
     "ember-cli-ic-ajax": "0.2.1",
     "ember-cli-inject-live-reload": "^1.3.1",
+    "ember-cli-moment-shim": "0.6.2",
     "ember-cli-qunit": "^1.0.0",
     "ember-cli-release": "0.2.3",
     "ember-cli-sri": "^1.0.3",

--- a/tests/dummy/app/initializers/setup-pikaday-i18n.js
+++ b/tests/dummy/app/initializers/setup-pikaday-i18n.js
@@ -1,6 +1,5 @@
-/* globals moment */
-
 import Ember from 'ember';
+import moment from 'moment';
 
 export default {
   name: 'setup-pikaday-i18n',


### PR DESCRIPTION
I'm not sure if this is desired by you, but this addon and ember-moment localization doesn't work very well together.

This pull request makes use of `ember-cli-moment-shim` which in turn makes the conflict between ember-pikaday and ember-moment disappear.

For reference: https://github.com/stefanpenner/ember-moment/issues/110

I'm kind of new to contributing to addons, but the tests do seem to pass. And pikaday works fine in my application still.