### PR TITLE
Changes necessary to nest Addons

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,10 @@ module.exports = {
   name: 'ember-pikaday',
 
   included: function(app) {
+     // see: https://github.com/ember-cli/ember-cli/issues/3718
+    if (typeof app.import !== 'function' && app.app) {
+      app = app.app;
+    }
     this._super.included(app);
 
     app.import(app.bowerDirectory + '/pikaday/pikaday.js');


### PR DESCRIPTION
These fixes allow ember-pikaday to be used as a Nested addon.

check out https://github.com/ember-cli/ember-cli/issues/3718 for a detailed error description for what happens currently without this patch.