### PR TITLE
Add inputless pikaday

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,10 @@ You can pass any custom pikaday option through the component like this
 
 Please refer to [pikaday configuration](https://github.com/dbushell/Pikaday#configuration)
 
+## Inputless pikaday
+
+If you don't want to show an input field, you can use the `pikaday-inputless` component instead of `pikaday-input`. It has the same API, but doesn't support `onOpen` and `onClose`. When `disabled=true` on a `pikaday-inputless`, the datepicker gets hidden.
+
 ## Localization
 
 Localizing the datepicker is possible in two steps. To localize the output of the datepicker, this is the formatted string visible in the input field, you simply include all the locales by following the [ember-cli-moment-shim instructions](https://github.com/jasonmit/ember-cli-moment-shim#cherry-pick-locales-optimal) and include the following in your `ember-cli-build.js`

--- a/addon/components/pikaday-input.js
+++ b/addon/components/pikaday-input.js
@@ -1,10 +1,7 @@
-/* globals Pikaday */
 import Ember from 'ember';
-import moment from 'moment';
+import PikadayMixin from 'ember-pikaday/mixins/pikaday';
 
-const { isPresent } = Ember;
-
-export default Ember.Component.extend({
+export default Ember.Component.extend(PikadayMixin, {
   tagName: 'input',
 
   attributeBindings: [
@@ -21,96 +18,10 @@ export default Ember.Component.extend({
 
   type: 'text',
 
-  _options: Ember.computed('options', 'i18n', {
-    get() {
-      let options = this._defaultOptions();
-
-      if (isPresent(this.get('i18n'))) {
-        options.i18n = this.get('i18n');
-      }
-      if (isPresent(this.get('position'))) {
-        options.position = this.get('position');
-      }
-      if (isPresent(this.get('reposition'))) {
-        options.reposition = this.get('reposition');
-      }
-
-      Ember.merge(options, this.get('options') || {});
-      return options;
-    }
-  }),
-
-  _defaultOptions() {
-    const firstDay = this.get('firstDay');
-
-    return {
-      field: this.element,
-      onOpen: Ember.run.bind(this, this.onPikadayOpen),
-      onClose: Ember.run.bind(this, this.onPikadayClose),
-      onSelect: Ember.run.bind(this, this.onPikadaySelect),
-      onDraw: Ember.run.bind(this, this.onPikadayRedraw),
-      firstDay: (typeof firstDay !== 'undefined') ? parseInt(firstDay, 10) : 1,
-      format: this.get('format') || 'DD.MM.YYYY',
-      yearRange: this.determineYearRange(),
-      minDate: this.get('minDate') || null,
-      maxDate: this.get('maxDate') || null,
-      theme: this.get('theme') || null
-    };
-  },
-
   didInsertElement() {
+    this.set('field', this.element);
     this.setupPikaday();
   },
-
-  didUpdateAttrs({ newAttrs }) {
-    this._super(...arguments);
-    this.setPikadayDate();
-    this.setMinDate();
-    this.setMaxDate();
-
-    if(newAttrs.options) {
-      this._updateOptions();
-    }
-  },
-
-  didRender() {
-    this._super(...arguments);
-    this.autoHideOnDisabled();
-  },
-
-  setupPikaday() {
-    let pikaday = new Pikaday(this.get('_options'));
-
-    this.set('pikaday', pikaday);
-    this.setPikadayDate();
-  },
-
-  willDestroyElement() {
-    this.get('pikaday').destroy();
-  },
-
-  setPikadayDate: function() {
-    const value = this.get('value');
-    const date = this.get('useUTC') ? moment(moment.utc(value).format('YYYY-MM-DD')).toDate() : value;
-    this.get('pikaday').setDate(date, true);
-  },
-
-  setMinDate: function() {
-    if (this.get('minDate')) {
-      this.get('pikaday').setMinDate(this.get('minDate'));
-    }
-  },
-
-  setMaxDate: function() {
-    if (this.get('maxDate')) {
-      this.get('pikaday').setMaxDate(this.get('maxDate'));
-    }
-  },
-
-  onOpen: Ember.K,
-  onClose: Ember.K,
-  onSelection: Ember.K,
-  onDraw: Ember.K,
 
   onPikadayOpen: function() {
     this.get('onOpen')();
@@ -124,52 +35,4 @@ export default Ember.Component.extend({
 
     this.get('onClose')();
   },
-
-  onPikadaySelect: function() {
-    this.userSelectedDate();
-  },
-
-  onPikadayRedraw: function() {
-    this.get('onDraw')();
-  },
-
-  userSelectedDate: function() {
-    var selectedDate = this.get('pikaday').getDate();
-
-    if (this.get('useUTC')) {
-      selectedDate = moment.utc([selectedDate.getFullYear(), selectedDate.getMonth(), selectedDate.getDate()]).toDate();
-    }
-
-    this.get('onSelection')(selectedDate);
-  },
-
-  determineYearRange: function() {
-    var yearRange = this.get('yearRange');
-
-    if (yearRange) {
-      if (yearRange.indexOf(',') > -1) {
-        var yearArray = yearRange.split(',');
-
-        if (yearArray[1] === 'currentYear') {
-          yearArray[1] = new Date().getFullYear();
-        }
-
-        return yearArray;
-      } else {
-        return yearRange;
-      }
-    } else {
-      return 10;
-    }
-  },
-
-  autoHideOnDisabled() {
-    if (this.get('disabled') && this.get('pikaday')) {
-      this.get('pikaday').hide();
-    }
-  },
-
-  _updateOptions() {
-    this.get('pikaday').config(this.get('_options'));
-  }
 });

--- a/addon/components/pikaday-inputless.js
+++ b/addon/components/pikaday-inputless.js
@@ -1,0 +1,16 @@
+import Ember from 'ember';
+import PikadayMixin from 'ember-pikaday/mixins/pikaday';
+import layout from 'ember-pikaday/templates/pikaday-inputless';
+
+export default Ember.Component.extend(PikadayMixin, {
+  layout,
+
+  didInsertElement() {
+    this.set('field', this.$('.ember-pikaday-input')[0]);
+    this.set('pikadayContainer', this.$('.ember-pikaday-container')[0]);
+    this.setupPikaday();
+  },
+
+  onPikadayOpen: Ember.K,
+  onPikadayClose: Ember.K,
+});

--- a/addon/mixins/pikaday.js
+++ b/addon/mixins/pikaday.js
@@ -1,0 +1,144 @@
+/* globals Pikaday */
+import Ember from 'ember';
+import moment from 'moment';
+
+const { isPresent } = Ember;
+
+export default Ember.Mixin.create({
+  _options: Ember.computed('options', 'i18n', {
+    get() {
+      let options = this._defaultOptions();
+
+      if (isPresent(this.get('i18n'))) {
+        options.i18n = this.get('i18n');
+      }
+      if (isPresent(this.get('position'))) {
+        options.position = this.get('position');
+      }
+      if (isPresent(this.get('reposition'))) {
+        options.reposition = this.get('reposition');
+      }
+
+      Ember.merge(options, this.get('options') || {});
+      return options;
+    }
+  }),
+
+  _defaultOptions() {
+    const firstDay = this.get('firstDay');
+
+    return {
+      field: this.get('field'),
+      container: this.get('pikadayContainer'),
+      bound: this.get('pikadayContainer') ? false : true,
+      onOpen: Ember.run.bind(this, this.onPikadayOpen),
+      onClose: Ember.run.bind(this, this.onPikadayClose),
+      onSelect: Ember.run.bind(this, this.onPikadaySelect),
+      onDraw: Ember.run.bind(this, this.onPikadayRedraw),
+      firstDay: (typeof firstDay !== 'undefined') ? parseInt(firstDay, 10) : 1,
+      format: this.get('format') || 'DD.MM.YYYY',
+      yearRange: this.determineYearRange(),
+      minDate: this.get('minDate') || null,
+      maxDate: this.get('maxDate') || null,
+      theme: this.get('theme') || null
+    };
+  },
+
+  didUpdateAttrs({ newAttrs }) {
+    this._super(...arguments);
+    this.setPikadayDate();
+    this.setMinDate();
+    this.setMaxDate();
+
+    if(newAttrs.options) {
+      this._updateOptions();
+    }
+  },
+
+  didRender() {
+    this._super(...arguments);
+    this.autoHideOnDisabled();
+  },
+
+  setupPikaday() {
+    let pikaday = new Pikaday(this.get('_options'));
+
+    this.set('pikaday', pikaday);
+    this.setPikadayDate();
+  },
+
+  willDestroyElement() {
+    this.get('pikaday').destroy();
+  },
+
+  setPikadayDate: function() {
+    const value = this.get('value');
+    const date = this.get('useUTC') ? moment(moment.utc(value).format('YYYY-MM-DD')).toDate() : value;
+    this.get('pikaday').setDate(date, true);
+  },
+
+  setMinDate: function() {
+    if (this.get('minDate')) {
+      this.get('pikaday').setMinDate(this.get('minDate'));
+    }
+  },
+
+  setMaxDate: function() {
+    if (this.get('maxDate')) {
+      this.get('pikaday').setMaxDate(this.get('maxDate'));
+    }
+  },
+
+  onOpen: Ember.K,
+  onClose: Ember.K,
+  onSelection: Ember.K,
+  onDraw: Ember.K,
+
+  onPikadaySelect: function() {
+    this.userSelectedDate();
+  },
+
+  onPikadayRedraw: function() {
+    this.get('onDraw')();
+  },
+
+  userSelectedDate: function() {
+    var selectedDate = this.get('pikaday').getDate();
+
+    if (this.get('useUTC')) {
+      selectedDate = moment.utc([selectedDate.getFullYear(), selectedDate.getMonth(), selectedDate.getDate()]).toDate();
+    }
+
+    this.get('onSelection')(selectedDate);
+  },
+
+  determineYearRange: function() {
+    var yearRange = this.get('yearRange');
+
+    if (yearRange) {
+      if (yearRange.indexOf(',') > -1) {
+        var yearArray = yearRange.split(',');
+
+        if (yearArray[1] === 'currentYear') {
+          yearArray[1] = new Date().getFullYear();
+        }
+
+        return yearArray;
+      } else {
+        return yearRange;
+      }
+    } else {
+      return 10;
+    }
+  },
+
+  autoHideOnDisabled() {
+    if (this.get('disabled') && this.get('pikaday')) {
+      this.get('pikaday').hide();
+    }
+  },
+
+  _updateOptions() {
+    this.get('pikaday').config(this.get('_options'));
+  }
+});

--- a/addon/templates/pikaday-inputless.hbs
+++ b/addon/templates/pikaday-inputless.hbs
@@ -1,0 +1,2 @@
+<input class="ember-pikaday-input" type="hidden">
+<div class="ember-pikaday-container"></div>

--- a/app/components/pikaday-inputless.js
+++ b/app/components/pikaday-inputless.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-pikaday/components/pikaday-inputless';

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "ember-cli": "2.5.1",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-dependency-checker": "^1.2.0",
-    "ember-cli-htmlbars": "^1.0.3",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-inject-live-reload": "^1.4.0",
     "ember-cli-moment-shim": "~0.6.2",
@@ -45,7 +44,8 @@
     "datepicker"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.6"
+    "ember-cli-babel": "^5.1.6",
+    "ember-cli-htmlbars": "^1.0.3"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -16,3 +16,9 @@ Datepicker with bound and set value:
 
 Datepicker already disabled before it's rendered:
 {{pikaday-input disabled="disabled"}}
+
+<br>
+
+Inputless datepicker:
+{{pikaday-inputless onSelection=(action (mut someDate))}}
+{{someDate}}

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -8,7 +8,7 @@ Standalone datepicker:
 <br>
 
 Datepicker with bound and set value:
-{{pikaday-input value=startDate format='DD.MM.YYYY'}}
+{{pikaday-input value=startDate onSelection=(action (mut startDate)) format='DD.MM.YYYY'}}
 {{startDate}}
 <br>
 <button {{action "clearStartDate"}}>Clear Date</button>

--- a/tests/integration/components/pikaday-inputless-test.js
+++ b/tests/integration/components/pikaday-inputless-test.js
@@ -1,0 +1,39 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import { openDatepicker } from 'ember-pikaday/helpers/pikaday';
+
+moduleForComponent('pikaday-inputless', 'Integration | Component | pikaday inputless', {
+  integration: true
+});
+
+test('it has no input tag visible', function(assert) {
+  this.render(hbs`{{pikaday-inputless}}`);
+  assert.equal(this.$('input[type=hidden]').length, 1);
+});
+
+test('selecting a date should send an action', function(assert) {
+  const expectedDate = new Date(2013, 3, 28);
+  this.on('onSelection', function(selectedDate) {
+    assert.deepEqual(selectedDate, expectedDate);
+  });
+  this.render(hbs`{{pikaday-inputless onSelection=(action 'onSelection')}}`);
+
+  let interactor = openDatepicker(this.$('input'));
+  interactor.selectDate(expectedDate);
+});
+
+test('setting the value attribute should select the correct date', function(assert) {
+  this.set('value', new Date(2010, 7, 10));
+  this.render(hbs`{{pikaday-inputless value=value}}`);
+
+  var interactor = openDatepicker(this.$('input'));
+
+  assert.equal(interactor.selectedYear(), 2010);
+  assert.equal(interactor.selectedMonth(), 7);
+  assert.equal(interactor.selectedDay(), 10);
+});
+
+test('using disabled hides the picker', function(assert) {
+  this.render(hbs`{{pikaday-inputless disabled=true}}`);
+  assert.ok($('.pika-single').hasClass('is-hidden'), 'should be closed before clicking');
+});


### PR DESCRIPTION
We've had an inputless datepicker running from our fork since a few months, but now that #67 has landed it's time for a PR!

This refactors common logic for both components into a mixin.
The inputless component sets the field for pikaday to a hidden input field and the container to a div in a template.
For the inputless component `onOpen` and `onClose` do nothing.

I wasn't sure what tests to port, since a lot of the behavior is shared between `pikaday-input` and `pikaday-inputless`, so I just tested what I thought makes sense.

Closes #58 