### PR TITLE
add observer for value

### DIFF
--- a/addon/components/pikaday-input.js
+++ b/addon/components/pikaday-input.js
@@ -73,6 +73,10 @@ export default Ember.Component.extend({
     }
   },
 
+  valueChanged: Ember.observer('value', function() {
+    this.setPikadayDate();
+  }),
+
   didRender() {
     this._super(...arguments);
     this.autoHideOnDisabled();

--- a/addon/components/pikaday-input.js
+++ b/addon/components/pikaday-input.js
@@ -94,9 +94,13 @@ export default Ember.Component.extend({
   },
 
   setPikadayDate: function() {
+    let pikaday = this.get('pikaday');
+    if(!pikaday) {
+      return;
+    }
     const value = this.get('value');
     const date = this.get('useUTC') ? moment(moment.utc(value).format('YYYY-MM-DD')).toDate() : value;
-    this.get('pikaday').setDate(date, true);
+    pikaday.setDate(date, true);
   },
 
   setMinDate: function() {


### PR DESCRIPTION
At least for Ember 1.13.8, the didUpdateAttrs was not picking up the value change before rerendering.  Adding an observer for value fixed the issue.

Thanks for the great addon.