### PR TITLE
Issue 93: Pass format string to moment to avoid deprecation warning

### DIFF
--- a/addon/components/pikaday-input.js
+++ b/addon/components/pikaday-input.js
@@ -90,8 +90,9 @@ export default Ember.Component.extend({
   },
 
   setPikadayDate: function() {
+    const DATE_FORMAT = 'YYYY-MM-DD';
     const value = this.get('value');
-    const date = this.get('useUTC') ? moment(moment.utc(value).format('YYYY-MM-DD')).toDate() : value;
+    const date = this.get('useUTC') ? moment(moment.utc(value).format(DATE_FORMAT), DATE_FORMAT).toDate() : value;
     this.get('pikaday').setDate(date, true);
   },
 


### PR DESCRIPTION
- New versions of moment desire a format string passed to the moment
  constructor