### PR TITLE
jump to date when min updated

### DIFF
--- a/addon/components/pikaday-input.js
+++ b/addon/components/pikaday-input.js
@@ -98,6 +98,7 @@ export default Ember.Component.extend({
   setMinDate: function() {
     if (this.get('minDate')) {
       this.get('pikaday').setMinDate(this.get('minDate'));
+      this.get('pikaday').gotoDate(this.get('minDate'));
     }
   },
 


### PR DESCRIPTION
The default behavior for pikaday leaves the datepicker at the current date when the min date is updated after render.  That means that if the min date is set to the future you're looking at a blocked off month and have to tab over.

This just tells it to jump also.  May not be useful for everyone.