### PR TITLE
include an example for disableDayFn option

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ You can pass any custom pikaday option through the component like this
 
 ```handlebars
 <label>
-  {{pikaday-input options=(hash numberOfMonths=2 disableWeekends=true)}}
+  {{pikaday-input options=(hash numberOfMonths=2 disableWeekends=true disableDayFn=(action 'someAction'))}}
 </label>
 ```
 


### PR DESCRIPTION
The disableDayFn option is a bit trickier than the others since it needs to be passed a function. I think others would avoid the same confusion I had with an easy little example.