### PR TITLE
Update included hook for nested addons

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,19 +5,13 @@ module.exports = {
   name: 'ember-pikaday',
 
   included: function(app) {
-    // When ember-pikaday is used in another addon we have to do some work
-    // upfront. See this issue for more information:
-    // https://github.com/ember-cli/ember-cli/issues/3718
-    if (typeof app.import !== 'function' && app.app) {
-      app = app.app;
-    }
+    this._super.included.apply(this, arguments);
 
-    this._super.included(app);
-
-    var options = app.options.emberPikaday || {};
+    var host = this._findHost();
+    var options = host.options.emberPikaday || {};
     if (!options.excludePikadayAssets) {
-      app.import(app.bowerDirectory + '/pikaday/pikaday.js');
-      app.import(app.bowerDirectory + '/pikaday/css/pikaday.css');
+      this.import(host.bowerDirectory + '/pikaday/pikaday.js');
+      this.import(host.bowerDirectory + '/pikaday/css/pikaday.css');
     }
   }
 };

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.6",
-    "ember-cli-htmlbars": "^1.0.3"
+    "ember-cli-htmlbars": "^1.0.3",
+    "ember-cli-import-polyfill": "^0.2.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
I update the to add the feature to be nested into another addon. I add `ember-cli-import-polyfill` to have access to the new `this.import` syntax and the polyfill add a nice function  `_findHost` to retrieve informations of the top parent app.
