### PR TITLE
Wraps set min/max dates later so they get fired correctly.

### DIFF
--- a/addon/mixins/pikaday.js
+++ b/addon/mixins/pikaday.js
@@ -2,7 +2,10 @@
 import Ember from 'ember';
 import moment from 'moment';
 
-const { isPresent } = Ember;
+const {
+  isPresent,
+  run,
+} = Ember;
 const assign = Ember.assign || Ember.merge;
 
 export default Ember.Mixin.create({
@@ -32,10 +35,10 @@ export default Ember.Mixin.create({
       field: this.get('field'),
       container: this.get('pikadayContainer'),
       bound: this.get('pikadayContainer') ? false : true,
-      onOpen: Ember.run.bind(this, this.onPikadayOpen),
-      onClose: Ember.run.bind(this, this.onPikadayClose),
-      onSelect: Ember.run.bind(this, this.onPikadaySelect),
-      onDraw: Ember.run.bind(this, this.onPikadayRedraw),
+      onOpen: run.bind(this, this.onPikadayOpen),
+      onClose: run.bind(this, this.onPikadayClose),
+      onSelect: run.bind(this, this.onPikadaySelect),
+      onDraw: run.bind(this, this.onPikadayRedraw),
       firstDay: (typeof firstDay !== 'undefined') ? parseInt(firstDay, 10) : 1,
       format: this.get('format') || 'DD.MM.YYYY',
       yearRange: this.determineYearRange(),
@@ -87,13 +90,17 @@ export default Ember.Mixin.create({
 
   setMinDate: function() {
     if (this.get('minDate')) {
-      this.get('pikaday').setMinDate(this.get('minDate'));
+      run.later(() => {
+        this.get('pikaday').setMinDate(this.get('minDate'));
+      });
     }
   },
 
   setMaxDate: function() {
     if (this.get('maxDate')) {
-      this.get('pikaday').setMaxDate(this.get('maxDate'));
+      run.later(() => {
+        this.get('pikaday').setMaxDate(this.get('maxDate'));
+      });
     }
   },
 

--- a/tests/integration/components/pikaday-input-test.js
+++ b/tests/integration/components/pikaday-input-test.js
@@ -1,6 +1,13 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { openDatepicker } from 'ember-pikaday/helpers/pikaday';
+import Ember from 'ember';
+
+const later = Ember.run.later;
+
+const {
+  run,
+} = Ember;
 
 const getFirstWeekendDayNumber = function() {
   let date = new Date();
@@ -15,7 +22,20 @@ function closePikaday(context) {
 }
 
 moduleForComponent('pikaday-input', 'Integration | Component | pikaday input', {
-  integration: true
+  integration: true,
+  beforeEach() {
+    Ember.run.later = function(ctx, fn) {
+      if (typeof fn === 'function') {
+        Ember.run.bind(ctx, fn)();
+      } else {
+        ctx();
+      }
+    };
+  },
+
+  afterEach() {
+    Ember.run.later = later;
+  },
 });
 
 test('it is an input tag', function(assert) {
@@ -120,7 +140,10 @@ test('set min date', function(assert) {
   tomorrow.setDate(tomorrow.getDate() + 1);
   this.set('tomorrow', tomorrow);
   this.render(hbs`{{pikaday-input minDate=tomorrow}}`);
-  this.$('input').click();
+
+  run(() => {
+    this.$('input').click();
+  });
 
   assert.ok($('.is-today').hasClass('is-disabled'));
 });
@@ -130,25 +153,38 @@ test('set max date', function(assert) {
   yesterday.setDate(yesterday.getDate() - 1);
   this.set('yesterday', yesterday);
   this.render(hbs`{{pikaday-input maxDate=yesterday}}`);
-  this.$('input').click();
+
+  run(() => {
+    this.$('input').click();
+  });
 
   assert.ok($('.is-today').hasClass('is-disabled'));
 });
 
 test('set new date value with a new min date', function(assert) {
   var tommorow = new Date(2010, 7, 10);
+
   this.set('tommorow', tommorow);
   this.render(hbs`{{pikaday-input value=tommorow minDate=tommorow}}`);
-  this.set('tommorow', new Date(2010, 7, 9));
+
+  run(() => {
+    this.set('tommorow', new Date(2010, 7, 9));
+  });
+
   assert.equal(this.$('input').val(), '09.08.2010');
 });
 
 
 test('set new date value with a new max date', function(assert) {
   var tommorow = new Date(2010, 7, 10);
+
   this.set('tommorow', tommorow);
   this.render(hbs`{{pikaday-input value=tommorow maxDate=tommorow}}`);
-  this.set('tommorow', new Date(2010, 7, 11));
+
+  run(() => {
+    this.set('tommorow', new Date(2010, 7, 11));
+  });
+
   assert.equal(this.$('input').val(), '11.08.2010');
 });
 


### PR DESCRIPTION
Before this change, if you have calendars A and B on the same screen and update the min/max date on B by changing the date value on A, the property gets updated correctly, but the pikaday calendar in the DOM does not.

I attempted to reproduce this in the `pikaday-input` integration test, but wasn't able to.