### PR TITLE
Tests and fix in pikaday mixin

### DIFF
--- a/addon/mixins/pikaday.js
+++ b/addon/mixins/pikaday.js
@@ -46,9 +46,9 @@ export default Ember.Mixin.create({
 
   didUpdateAttrs({ newAttrs }) {
     this._super(...arguments);
-    this.setPikadayDate();
     this.setMinDate();
     this.setMaxDate();
+    this.setPikadayDate();
 
     if(newAttrs.options) {
       this._updateOptions();

--- a/tests/integration/components/pikaday-input-test.js
+++ b/tests/integration/components/pikaday-input-test.js
@@ -135,6 +135,23 @@ test('set max date', function(assert) {
   assert.ok($('.is-today').hasClass('is-disabled'));
 });
 
+test('set new date value with a new min date', function(assert) {
+  var tommorow = new Date(2010, 7, 10);
+  this.set('tommorow', tommorow);
+  this.render(hbs`{{pikaday-input value=tommorow minDate=tommorow}}`);
+  this.set('tommorow', new Date(2010, 7, 9));
+  assert.equal(this.$('input').val(), '09.08.2010');
+});
+
+
+test('set new date value with a new max date', function(assert) {
+  var tommorow = new Date(2010, 7, 10);
+  this.set('tommorow', tommorow);
+  this.render(hbs`{{pikaday-input value=tommorow maxDate=tommorow}}`);
+  this.set('tommorow', new Date(2010, 7, 11));
+  assert.equal(this.$('input').val(), '11.08.2010');
+});
+
 test('theme option adds theme as CSS class to DOM element', function(assert) {
   this.render(hbs`{{pikaday-input theme='dark-theme'}}`);
 


### PR DESCRIPTION
Running set min/max date after serPikadayDate prevented a new date inside the new time span but outside the old to be set. Moved both operations before serPikadayDate and wrote tests checking the value of the input box to reflect the new date being sent in after a min/max change. 