### PR TITLE
Change month & year selector in helper to support default hidden dropdown

### DIFF
--- a/addon/helpers/pikaday.js
+++ b/addon/helpers/pikaday.js
@@ -9,8 +9,8 @@ var openDatepicker = function(element) {
 };
 
 var PikadayInteractor = {
-  selectorForMonthSelect: '.pika-select-month:visible',
-  selectorForYearSelect: '.pika-select-year:visible',
+  selectorForMonthSelect: '.pika-lendar:visible .pika-select-month',
+  selectorForYearSelect: '.pika-lendar:visible .pika-select-year',
   selectDate: function(date) {
     var day = date.getDate();
     var month = date.getMonth();


### PR DESCRIPTION
By default, the `<select />` element in Pikaday is hidden, so the helper doesn't actually change the date - worse, it throws an exception since the `$(selectorForMonthSelector)` array is empty.
This change allows to pick the active datepicker and change the date through the helper function, for example in acceptance tests.