### PR TITLE
Fixed deprecation for Ember.merge

### DIFF
--- a/addon/mixins/pikaday.js
+++ b/addon/mixins/pikaday.js
@@ -3,7 +3,7 @@ import Ember from 'ember';
 import moment from 'moment';
 
 const { isPresent } = Ember;
-const assign = Ember.assign || Ember.merge
+const assign = Ember.assign || Ember.merge;
 
 export default Ember.Mixin.create({
   _options: Ember.computed('options', 'i18n', {

--- a/addon/mixins/pikaday.js
+++ b/addon/mixins/pikaday.js
@@ -3,6 +3,7 @@ import Ember from 'ember';
 import moment from 'moment';
 
 const { isPresent } = Ember;
+const assign = Ember.assign || Ember.merge
 
 export default Ember.Mixin.create({
   _options: Ember.computed('options', 'i18n', {
@@ -19,7 +20,7 @@ export default Ember.Mixin.create({
         options.reposition = this.get('reposition');
       }
 
-      Ember.merge(options, this.get('options') || {});
+      assign(options, this.get('options') || {});
       return options;
     }
   }),


### PR DESCRIPTION
Ember has deprecated Ember.merge and suggests using Ember.assign instead.