### PR TITLE
Get pikaday from npm instead of Bower

### DIFF
--- a/blueprints/ember-pikaday/index.js
+++ b/blueprints/ember-pikaday/index.js
@@ -2,10 +2,6 @@ module.exports = {
   normalizeEntityName: function() {},
 
   afterInstall: function() {
-    var that = this;
-
-    return this.addBowerPackageToProject('pikaday').then(function() {
-      return that.addAddonToProject('ember-cli-moment-shim', '1.1.0');
-    });
+    return this.addAddonToProject('ember-cli-moment-shim', '2.1.0');
   }
 };

--- a/bower.json
+++ b/bower.json
@@ -1,8 +1,6 @@
 {
   "name": "ember-pikaday",
   "dependencies": {
-    "pikaday": "~1.4.0",
-    "moment": ">= 2.8.0",
     "ember": "~2.5.0",
     "ember-cli-shims": "0.1.1",
     "ember-cli-test-loader": "0.2.2",

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -13,10 +13,6 @@ module.exports = function(defaults) {
     This build file does *not* influence how the addon or the app using it
     behave. You most likely want to be modifying `./index.js` or app's build file
   */
-  app.import(app.bowerDirectory + '/moment/moment.js');
-  app.import(app.bowerDirectory + '/moment/locale/de-at.js');
-  app.import(app.bowerDirectory + '/pikaday/pikaday.js');
-  app.import(app.bowerDirectory + '/pikaday/css/pikaday.css');
 
   return app.toTree();
 };

--- a/index.js
+++ b/index.js
@@ -4,20 +4,11 @@
 module.exports = {
   name: 'ember-pikaday',
 
-  included: function(app) {
-    // When ember-pikaday is used in another addon we have to do some work
-    // upfront. See this issue for more information:
-    // https://github.com/ember-cli/ember-cli/issues/3718
-    if (typeof app.import !== 'function' && app.app) {
-      app = app.app;
-    }
-
-    this._super.included(app);
-
-    var options = app.options.emberPikaday || {};
-    if (!options.excludePikadayAssets) {
-      app.import(app.bowerDirectory + '/pikaday/pikaday.js');
-      app.import(app.bowerDirectory + '/pikaday/css/pikaday.css');
+  options: {
+    nodeAssets: {
+      pikaday: {
+        import: ['pikaday.js', 'css/pikaday.css']
+      }
     }
   }
 };

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "ember-cli-dependency-checker": "^1.2.0",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-inject-live-reload": "^1.4.0",
-    "ember-cli-moment-shim": "~0.6.2",
     "ember-cli-jshint": "^1.0.0",
+    "ember-cli-moment-shim": "~2.1.0",
     "ember-cli-qunit": "^1.4.0",
     "ember-cli-release": "0.2.8",
     "ember-cli-sri": "^2.1.0",
@@ -45,7 +45,9 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.6",
-    "ember-cli-htmlbars": "^1.0.3"
+    "ember-cli-htmlbars": "^1.0.3",
+    "ember-cli-node-assets": "^0.1.4",
+    "pikaday": "^1.4.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
This implements #114.

I also upgraded the `ember-cli-moment-shim` which does not use moment from bower as well.