### PR TITLE
Remove pikaday.js from fastboot build

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,10 @@ module.exports = {
   options: {
     nodeAssets: {
       pikaday: {
-        import: ['pikaday.js', 'css/pikaday.css']
+        import: [
+          { enabled: process.env.EMBER_CLI_FASTBOOT !== 'true', path: 'pikaday.js' },
+          'css/pikaday.css'
+        ]
       }
     }
   }


### PR DESCRIPTION
This makes the addon to work with fastboot. When building for fastboot, it will not include the pikaday.js, but when building for the browser it will include the file.

Closes #109.