### PR TITLE
Added behavior to enforce that the current date is between the given intervals at any time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary
+  - EMBER_TRY_SCENARIO=ember-2.8.3
   - EMBER_TRY_SCENARIO=ember-2.4.3
   - EMBER_TRY_SCENARIO=ember-2.3.1
   - EMBER_TRY_SCENARIO=ember-2.2.2

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ The `maxDate` attribute is supported as a binding so you can set the latest date
 </label>
 ```
 
-The component can react if the current date value is lower than the minDate or above the max date. To activate this beavior `enforceDateIntervals` should be used.
+The component can react if the current date value is lower than `minDate` or above `maxDate`. To activate this beavior `enforceDateIntervals` should be used.
 
 When `enforceDateIntervals` is `true` the component will set the pikaday date to minDate or maxDate (currentDate < minDate or currentDate > maxDate) and call `onSelection` with the new date.
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ The `maxDate` attribute is supported as a binding so you can set the latest date
 
 The component can react if the current date value is lower than `minDate` or above `maxDate`. To activate this beavior `enforceDateIntervals` should be used.
 
-When `enforceDateIntervals` is `true` the component will set the pikaday date to minDate or maxDate (currentDate < minDate or currentDate > maxDate) and call `onSelection` with the new date.
+When `enforceDateIntervals` is `true` the component will call `onSelection` passing it `minDate` or `maxDate`.
 
 ```handlebars
 <label>

--- a/README.md
+++ b/README.md
@@ -139,6 +139,16 @@ The `maxDate` attribute is supported as a binding so you can set the latest date
 </label>
 ```
 
+The component can react if the current date value is lower than the minDate or above the max date. To activate this beavior `enforceDateIntervals` should be used.
+
+When `enforceDateIntervals` is `true` the component will set the pikaday date to minDate or maxDate (currentDate < minDate or currentDate > maxDate) and call `onSelection` with the new date.
+
+```handlebars
+<label>
+  {{pikaday-input maxDate=maxDate minDate=minDate enforceDateIntervals=true}}
+</label>
+```
+
 ## Return dates in UTC time zone
 
 The date returned by ember-pikaday is in your local time zone due to the JavaScript default behaviour of `new Date()`. This can lead to problems when your application converts the date to UTC. In additive time zones (e.g. +0010) the resulting converted date could be yesterdays date. You can force the component to return a date with the UTC time zone by passing `useUTC=true` to it.

--- a/README.md
+++ b/README.md
@@ -139,16 +139,6 @@ The `maxDate` attribute is supported as a binding so you can set the latest date
 </label>
 ```
 
-The component can react if the current date value is lower than `minDate` or above `maxDate`. To activate this beavior `enforceDateIntervals` should be used.
-
-When `enforceDateIntervals` is `true` the component will call `onSelection` passing it `minDate` or `maxDate`.
-
-```handlebars
-<label>
-  {{pikaday-input maxDate=maxDate minDate=minDate enforceDateIntervals=true}}
-</label>
-```
-
 ## Return dates in UTC time zone
 
 The date returned by ember-pikaday is in your local time zone due to the JavaScript default behaviour of `new Date()`. This can lead to problems when your application converts the date to UTC. In additive time zones (e.g. +0010) the resulting converted date could be yesterdays date. You can force the component to return a date with the UTC time zone by passing `useUTC=true` to it.

--- a/addon/mixins/pikaday.js
+++ b/addon/mixins/pikaday.js
@@ -107,11 +107,13 @@ export default Ember.Mixin.create({
     const { enforceDateIntervals, pikaday, minDate, value } = getProperties(this, [ 'enforceDateIntervals', 'pikaday', 'minDate', 'value' ]);
 
     if (minDate) {
-      run.later( () => {
+      run.later(() => {
         pikaday.setMinDate(minDate);
+      });
 
-        // Force current value to not be lower than minDate
-        if ( enforceDateIntervals && value < minDate) {
+      // Force current value to not be greated than maxDate
+      run.schedule('sync', () => {
+        if ( enforceDateIntervals && value < minDate ) {
           get(this, 'onSelection')(minDate);
         }
       });
@@ -122,10 +124,12 @@ export default Ember.Mixin.create({
     const { enforceDateIntervals, pikaday, maxDate, value }  = getProperties(this, [ 'enforceDateIntervals', 'pikaday', 'maxDate', 'value' ]);
 
     if (maxDate) {
-      run.later( () => {
+      run.later(() => {
         pikaday.setMaxDate(maxDate);
+      });
 
-        // Force current value to not be greated than maxDate
+      // Force current value to not be greated than maxDate
+      run.schedule('sync', () => {
         if ( enforceDateIntervals && value > maxDate ) {
           get(this, 'onSelection')(maxDate);
         }

--- a/addon/mixins/pikaday.js
+++ b/addon/mixins/pikaday.js
@@ -4,7 +4,6 @@ import moment from 'moment';
 
 const {
   isPresent,
-  get,
   run,
   getProperties
 } = Ember;
@@ -12,7 +11,6 @@ const {
 const assign = Ember.assign || Ember.merge;
 
 export default Ember.Mixin.create({
-  enforceDateIntervals: false,
 
   _options: Ember.computed('options', 'i18n', {
     get() {
@@ -104,35 +102,23 @@ export default Ember.Mixin.create({
   },
 
   setMinDate: function() {
-    const { enforceDateIntervals, pikaday, minDate, value } = getProperties(this, [ 'enforceDateIntervals', 'pikaday', 'minDate', 'value' ]);
+    const { pikaday, minDate } = getProperties(this, [ 'pikaday', 'minDate' ]);
 
     if (minDate) {
       run.later(() => {
         pikaday.setMinDate(minDate);
-      });
-
-      // Force current value to not be greated than maxDate
-      run.schedule('sync', () => {
-        if ( enforceDateIntervals && value < minDate ) {
-          get(this, 'onSelection')(minDate);
-        }
+        pikaday.setDate(minDate);
       });
     }
   },
 
   setMaxDate: function() {
-    const { enforceDateIntervals, pikaday, maxDate, value }  = getProperties(this, [ 'enforceDateIntervals', 'pikaday', 'maxDate', 'value' ]);
+    const { pikaday, maxDate }  = getProperties(this, [ 'pikaday', 'maxDate' ]);
 
     if (maxDate) {
       run.later(() => {
         pikaday.setMaxDate(maxDate);
-      });
-
-      // Force current value to not be greated than maxDate
-      run.schedule('sync', () => {
-        if ( enforceDateIntervals && value > maxDate ) {
-          get(this, 'onSelection')(maxDate);
-        }
+        pikaday.setDate(maxDate);
       });
     }
   },

--- a/addon/mixins/pikaday.js
+++ b/addon/mixins/pikaday.js
@@ -110,11 +110,11 @@ export default Ember.Mixin.create({
       });
 
       // If the current date is lower than minDate we set date to minDate
-      if (value < minDate) {
-        run.schedule('sync', () => {
+      run.schedule('sync', () => {
+        if (value < minDate) {
           pikaday.setDate(minDate);
-        });
-      }
+        }
+      });
     }
   },
 
@@ -127,11 +127,11 @@ export default Ember.Mixin.create({
       });
 
       // If the current date is greater than maxDate we set date to maxDate
-      if (value > maxDate) {
-        run.schedule('sync', () => {
+      run.schedule('sync', () => {
+        if (value > maxDate) {
           pikaday.setDate(maxDate);
-        });
-      }
+        }
+      });
     }
   },
 

--- a/addon/mixins/pikaday.js
+++ b/addon/mixins/pikaday.js
@@ -110,12 +110,11 @@ export default Ember.Mixin.create({
       run.later( () => {
         pikaday.setMinDate(minDate);
 
+        // Force current value to not be lower than minDate
+        if ( enforceDateIntervals && value < minDate) {
+          get(this, 'onSelection')(minDate);
+        }
       });
-      // Force current value to not be lower than minDate
-      if ( enforceDateIntervals && value < minDate) {
-        pikaday.setDate(minDate);
-        get(this, 'onSelection')(minDate);
-      }
     }
   },
 
@@ -128,7 +127,6 @@ export default Ember.Mixin.create({
 
         // Force current value to not be greated than maxDate
         if ( enforceDateIntervals && value > maxDate ) {
-          pikaday.setDate(maxDate);
           get(this, 'onSelection')(maxDate);
         }
       });

--- a/addon/mixins/pikaday.js
+++ b/addon/mixins/pikaday.js
@@ -102,24 +102,36 @@ export default Ember.Mixin.create({
   },
 
   setMinDate: function() {
-    const { pikaday, minDate } = getProperties(this, [ 'pikaday', 'minDate' ]);
+    const { pikaday, minDate, value } = getProperties(this, [ 'pikaday', 'minDate', 'value' ]);
 
     if (minDate) {
       run.later(() => {
         pikaday.setMinDate(minDate);
-        pikaday.setDate(minDate);
       });
+
+      // If the current date is lower than minDate we set date to minDate
+      if (value < minDate) {
+        run.schedule('sync', () => {
+          pikaday.setDate(minDate);
+        });
+      }
     }
   },
 
   setMaxDate: function() {
-    const { pikaday, maxDate }  = getProperties(this, [ 'pikaday', 'maxDate' ]);
+    const { pikaday, maxDate, value }  = getProperties(this, [ 'pikaday', 'maxDate', 'value' ]);
 
     if (maxDate) {
       run.later(() => {
         pikaday.setMaxDate(maxDate);
-        pikaday.setDate(maxDate);
       });
+
+      // If the current date is greater than maxDate we set date to maxDate
+      if (value > maxDate) {
+        run.schedule('sync', () => {
+          pikaday.setDate(maxDate);
+        });
+      }
     }
   },
 

--- a/addon/mixins/pikaday.js
+++ b/addon/mixins/pikaday.js
@@ -2,9 +2,16 @@
 import Ember from 'ember';
 import moment from 'moment';
 
-const { isPresent } = Ember;
+const {
+  isPresent,
+  set,
+  get,
+  getProperties
+} = Ember;
 
 export default Ember.Mixin.create({
+  enforceDateIntervals: false,
+
   _options: Ember.computed('options', 'i18n', {
     get() {
       let options = this._defaultOptions();
@@ -85,14 +92,30 @@ export default Ember.Mixin.create({
   },
 
   setMinDate: function() {
-    if (this.get('minDate')) {
-      this.get('pikaday').setMinDate(this.get('minDate'));
+    const { enforceDateIntervals, pikaday, minDate, value } = getProperties(this, [ 'enforceDateIntervals', 'pikaday', 'minDate', 'value' ]);
+
+    if (minDate) {
+      pikaday.setMinDate(minDate);
+
+      // Force current value to not be lower than minDate
+      if ( enforceDateIntervals && value < minDate) {
+        pikaday.setDate(minDate);
+        get(this, 'onSelection')(minDate);
+      }
     }
   },
 
   setMaxDate: function() {
-    if (this.get('maxDate')) {
-      this.get('pikaday').setMaxDate(this.get('maxDate'));
+    const { enforceDateIntervals, pikaday, maxDate, value }  = getProperties(this, [ 'enforceDateIntervals', 'pikaday', 'maxDate', 'value' ]);
+
+    if (maxDate) {
+      pikaday.setMaxDate(maxDate);
+
+      // Force current value to not be greated than maxDate
+      if ( enforceDateIntervals && value > maxDate ) {
+        pikaday.setDate(maxDate);
+        get(this, 'onSelection')(maxDate);
+      }
     }
   },
 

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -40,6 +40,17 @@ module.exports = {
       }
     },
     {
+      name: 'ember-2.8.3',
+      bower: {
+        dependencies: {
+          'ember': '2.8.3'
+        },
+        resolutions: {
+          'ember': '2.8.3'
+        }
+      }
+    },
+    {
       name: 'ember-2.4.3',
       bower: {
         dependencies: {

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 
 module.exports = {
   name: 'ember-pikaday',
-
+  
   options: {
     nodeAssets: {
       pikaday: {

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -9,5 +9,8 @@ export default Ember.Controller.extend({
     doSomethingWithSelectedValue(value) {
       console.log(value);
     }
-  }
+  },
+
+  neverGoBackDate: new Date(),
+  neverGoBackMinDate: Ember.computed.readOnly('neverGoBackDate')
 });

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -10,7 +10,4 @@ export default Ember.Controller.extend({
       console.log(value);
     }
   },
-
-  neverGoBackDate: new Date(),
-  neverGoBackMinDate: Ember.computed.readOnly('neverGoBackDate')
 });

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -22,10 +22,3 @@ Datepicker already disabled before it's rendered:
 Inputless datepicker:
 {{pikaday-inputless onSelection=(action (mut someDate))}}
 {{someDate}}
-
-Inputless datepicker never go back:
-{{pikaday-inputless value=neverGoBackDate onSelection=(action (mut neverGoBackDate)) minDate=neverGoBackMinDate }}
-
-Input datepicker never go back:
-{{pikaday-input value=neverGoBackDate onSelection=(action (mut neverGoBackDate)) minDate=neverGoBackMinDate }}
-

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -22,3 +22,10 @@ Datepicker already disabled before it's rendered:
 Inputless datepicker:
 {{pikaday-inputless onSelection=(action (mut someDate))}}
 {{someDate}}
+
+Inputless datepicker never go back:
+{{pikaday-inputless value=neverGoBackDate onSelection=(action (mut neverGoBackDate)) minDate=neverGoBackMinDate }}
+
+Input datepicker never go back:
+{{pikaday-input value=neverGoBackDate onSelection=(action (mut neverGoBackDate)) minDate=neverGoBackMinDate }}
+

--- a/tests/integration/components/pikaday-input-test.js
+++ b/tests/integration/components/pikaday-input-test.js
@@ -389,7 +389,7 @@ test('if updates pikaday config if options hash is changed', function(assert) {
   assert.notOk($(`td[data-day=${weekendDay}]`).hasClass('is-disabled'));
 });
 
-test('if minDate < value and enforceDateIntervals is true we call onSelection with minDate' ,function(assert) {
+test('if minDate is greater than value we we set pikaday\'s current date to minDate' ,function(assert) {
   assert.expect(1);
 
   let today = new Date();
@@ -403,7 +403,7 @@ test('if minDate < value and enforceDateIntervals is true we call onSelection wi
   assert.equal(this.get('currentDate').getDate(), tomorrow.getDate(), 'value should change');
 });
 
-test('if maxDate > value and enforceDateIntervals is true we call onSelection with maxDate', function(assert) {
+test('if maxDate is lower than value we set pikaday\'s current date to maxDate', function(assert) {
   assert.expect(1);
 
   let today = new Date();

--- a/tests/integration/components/pikaday-input-test.js
+++ b/tests/integration/components/pikaday-input-test.js
@@ -389,38 +389,60 @@ test('if updates pikaday config if options hash is changed', function(assert) {
   assert.notOk($(`td[data-day=${weekendDay}]`).hasClass('is-disabled'));
 });
 
-test('we force value = minDate if currentDate < minDate and sync requested' ,function(assert) {
-  assert.expect(2);
+test('if minDate < value and enforceDateIntervals is true we call onSelection with minDate' ,function(assert) {
+  assert.expect(1);
 
   let today = new Date();
   let tomorrow = new Date( Date.now() + (60 * 60 * 24 * 1000));
 
   this.set('currentDate', today);
   this.set('minDate', today);
-  this.set('forceSync', false);
-  this.render(hbs`{{pikaday-input enforceDateIntervals=forceSync minDate=minDate value=currentDate onSelection=(action (mut currentDate)) }}`);
+  this.render(hbs`{{pikaday-input enforceDateIntervals=true minDate=minDate value=currentDate onSelection=(action (mut currentDate)) }}`);
 
   this.set('minDate', tomorrow);
-  assert.equal(this.get('currentDate').getDate(), today.getDate(), 'value should not change as sync is not required');
-
-  this.set('forceSync', true);
   assert.equal(this.get('currentDate').getDate(), tomorrow.getDate(), 'value should change');
 });
 
-test('we force value = maxDate if  currentDate > maxDate and sync requested', function(assert) {
-  assert.expect(2);
+test("if minDate < value and enforceDateIntervals is false we do nothing", function(assert) {
+  assert.expect(1);
+
+  let today = new Date();
+  let tomorrow = new Date( Date.now() + (60 * 60 * 24 * 1000));
+
+  this.set('currentDate', today);
+  this.set('minDate', today);
+  this.render(hbs`{{pikaday-input enforceDateIntervals=false minDate=minDate value=currentDate onSelection=(action (mut currentDate)) }}`);
+
+  this.set('minDate', tomorrow);
+  assert.equal(this.get('currentDate').getDate(), today.getDate(), 'value should change');
+
+});
+
+test('if maxDate > value and enforceDateIntervals is true we call onSelection with maxDate', function(assert) {
+  assert.expect(1);
 
   let today = new Date();
   let tomorrow = new Date( Date.now() + (60 * 60 * 24 * 1000));
 
   this.set('currentDate', tomorrow);
   this.set('maxDate', tomorrow);
-  this.set('forceSync', false );
-  this.render(hbs`{{pikaday-input enforceDateIntervals=forceSync maxDate=maxDate value=currentDate onSelection=(action (mut currentDate)) }}`);
+  this.render(hbs`{{pikaday-input enforceDateIntervals=true maxDate=maxDate value=currentDate onSelection=(action (mut currentDate)) }}`);
 
   this.set('maxDate', today);
-  assert.equal(this.get('currentDate').getDate(), tomorrow.getDate(), 'value should not change as sync is not required');
-
-  this.set('forceSync', true);
   assert.equal(this.get('currentDate').getDate(), today.getDate(), 'value should change');
+});
+
+test("if maxDate > value and enforceDateIntervals is false we do nothing", function(assert) {
+  assert.expect(1);
+
+  let today = new Date();
+  let tomorrow = new Date( Date.now() + (60 * 60 * 24 * 1000));
+
+  this.set('currentDate', tomorrow);
+  this.set('maxDate', tomorrow);
+  this.render(hbs`{{pikaday-input enforceDateIntervals=false maxDate=maxDate value=currentDate onSelection=(action (mut currentDate)) }}`);
+
+  this.set('maxDate', today);
+  assert.equal(this.get('currentDate').getDate(), tomorrow.getDate(), 'value should change');
+
 });

--- a/tests/integration/components/pikaday-input-test.js
+++ b/tests/integration/components/pikaday-input-test.js
@@ -335,3 +335,43 @@ test('if updates pikaday config if options hash is changed', function(assert) {
   openDatepicker(this.$('input'));
   assert.notOk($(`td[data-day=${weekendDay}]`).hasClass('is-disabled'));
 });
+
+test('we force value = minDate if currentDate < minDate and sync requested' ,function(assert) {
+  assert.expect(4);
+
+  let today = new Date();
+  let tomorrow = new Date( Date.now() + (60 * 60 * 24 * 1000));
+
+  this.set('currentDate', today);
+  this.set('minDate', today);
+  this.set('forceSync', false);
+  this.render(hbs`{{pikaday-input enforceDateIntervals=forceSync minDate=minDate value=currentDate onSelection=(action (mut currentDate)) }}`);
+
+  this.set('minDate', tomorrow);
+  assert.equal(this.get('currentDate'), today, 'value should not change as sync is not required');
+  assert.equal(openDatepicker(this.$('input')).selectedDay(), today.getDate(), 'Pikadate date should not change as sync is not required');
+
+  this.set('forceSync', true);
+  assert.equal(this.get('currentDate'), tomorrow, 'value should change');
+  assert.equal(openDatepicker(this.$('input')).selectedDay(), tomorrow.getDate(), 'Pikadate date should change');
+});
+
+test('we force value = maxDate if  currentDate > maxDate and sync requested', function(assert) {
+  assert.expect(4);
+
+  let today = new Date();
+  let tomorrow = new Date( Date.now() + (60 * 60 * 24 * 1000));
+
+  this.set('currentDate', tomorrow);
+  this.set('maxDate', tomorrow);
+  this.set('forceSync', false );
+  this.render(hbs`{{pikaday-input enforceDateIntervals=forceSync maxDate=maxDate value=currentDate onSelection=(action (mut currentDate)) }}`);
+
+  this.set('maxDate', today);
+  assert.equal(this.get('currentDate'), tomorrow, 'value should not change as sync is not required');
+  assert.equal(openDatepicker(this.$('input')).selectedDay(), tomorrow.getDate(), 'Pikadate date should not change as sync is not required');
+
+  this.set('forceSync', true);
+  assert.equal(this.get('currentDate'), today, 'value should change');
+  assert.equal(openDatepicker(this.$('input')).selectedDay(), today.getDate(), 'Pikadate date should change');
+});

--- a/tests/integration/components/pikaday-input-test.js
+++ b/tests/integration/components/pikaday-input-test.js
@@ -401,10 +401,10 @@ test('we force value = minDate if currentDate < minDate and sync requested' ,fun
   this.render(hbs`{{pikaday-input enforceDateIntervals=forceSync minDate=minDate value=currentDate onSelection=(action (mut currentDate)) }}`);
 
   this.set('minDate', tomorrow);
-  assert.equal(this.get('currentDate'), today, 'value should not change as sync is not required');
+  assert.equal(this.get('currentDate').getDate(), today.getDate(), 'value should not change as sync is not required');
 
   this.set('forceSync', true);
-  assert.equal(this.get('currentDate'), tomorrow, 'value should change');
+  assert.equal(this.get('currentDate').getDate(), tomorrow.getDate(), 'value should change');
 });
 
 test('we force value = maxDate if  currentDate > maxDate and sync requested', function(assert) {
@@ -419,8 +419,8 @@ test('we force value = maxDate if  currentDate > maxDate and sync requested', fu
   this.render(hbs`{{pikaday-input enforceDateIntervals=forceSync maxDate=maxDate value=currentDate onSelection=(action (mut currentDate)) }}`);
 
   this.set('maxDate', today);
-  assert.equal(this.get('currentDate'), tomorrow, 'value should not change as sync is not required');
+  assert.equal(this.get('currentDate').getDate(), tomorrow.getDate(), 'value should not change as sync is not required');
 
   this.set('forceSync', true);
-  assert.equal(this.get('currentDate'), today, 'value should change');
+  assert.equal(this.get('currentDate').getDate(), today.getDate(), 'value should change');
 });

--- a/tests/integration/components/pikaday-input-test.js
+++ b/tests/integration/components/pikaday-input-test.js
@@ -397,7 +397,7 @@ test('if minDate is greater than value we we set pikaday\'s current date to minD
 
   this.set('currentDate', today);
   this.set('minDate', today);
-  this.render(hbs`{{pikaday-input enforceDateIntervals=true minDate=minDate value=currentDate onSelection=(action (mut currentDate)) }}`);
+  this.render(hbs`{{pikaday-input minDate=minDate value=currentDate onSelection=(action (mut currentDate)) }}`);
 
   this.set('minDate', tomorrow);
   assert.equal(this.get('currentDate').getDate(), tomorrow.getDate(), 'value should change');
@@ -411,7 +411,7 @@ test('if maxDate is lower than value we set pikaday\'s current date to maxDate',
 
   this.set('currentDate', tomorrow);
   this.set('maxDate', tomorrow);
-  this.render(hbs`{{pikaday-input enforceDateIntervals=true maxDate=maxDate value=currentDate onSelection=(action (mut currentDate)) }}`);
+  this.render(hbs`{{pikaday-input maxDate=maxDate value=currentDate onSelection=(action (mut currentDate)) }}`);
 
   this.set('maxDate', today);
   assert.equal(this.get('currentDate').getDate(), today.getDate(), 'value should change');

--- a/tests/integration/components/pikaday-input-test.js
+++ b/tests/integration/components/pikaday-input-test.js
@@ -403,21 +403,6 @@ test('if minDate < value and enforceDateIntervals is true we call onSelection wi
   assert.equal(this.get('currentDate').getDate(), tomorrow.getDate(), 'value should change');
 });
 
-test("if minDate < value and enforceDateIntervals is false we do nothing", function(assert) {
-  assert.expect(1);
-
-  let today = new Date();
-  let tomorrow = new Date( Date.now() + (60 * 60 * 24 * 1000));
-
-  this.set('currentDate', today);
-  this.set('minDate', today);
-  this.render(hbs`{{pikaday-input enforceDateIntervals=false minDate=minDate value=currentDate onSelection=(action (mut currentDate)) }}`);
-
-  this.set('minDate', tomorrow);
-  assert.equal(this.get('currentDate').getDate(), today.getDate(), 'value should change');
-
-});
-
 test('if maxDate > value and enforceDateIntervals is true we call onSelection with maxDate', function(assert) {
   assert.expect(1);
 
@@ -430,19 +415,4 @@ test('if maxDate > value and enforceDateIntervals is true we call onSelection wi
 
   this.set('maxDate', today);
   assert.equal(this.get('currentDate').getDate(), today.getDate(), 'value should change');
-});
-
-test("if maxDate > value and enforceDateIntervals is false we do nothing", function(assert) {
-  assert.expect(1);
-
-  let today = new Date();
-  let tomorrow = new Date( Date.now() + (60 * 60 * 24 * 1000));
-
-  this.set('currentDate', tomorrow);
-  this.set('maxDate', tomorrow);
-  this.render(hbs`{{pikaday-input enforceDateIntervals=false maxDate=maxDate value=currentDate onSelection=(action (mut currentDate)) }}`);
-
-  this.set('maxDate', today);
-  assert.equal(this.get('currentDate').getDate(), tomorrow.getDate(), 'value should change');
-
 });


### PR DESCRIPTION
When value < minDate or value  > maxDate the component will call onSelection passing minDate or maxDate respectively.

To activate this behavior we should pass `enforceDateIntervals=true` to the component.

The documentation for this feature has been also added to the README.