### PR TITLE
Fix enforcing minDate to allow null value

### DIFF
--- a/addon/mixins/pikaday.js
+++ b/addon/mixins/pikaday.js
@@ -111,7 +111,7 @@ export default Ember.Mixin.create({
 
       // If the current date is lower than minDate we set date to minDate
       run.schedule('sync', () => {
-        if (value < minDate) {
+        if (value && value < minDate) {
           pikaday.setDate(minDate);
         }
       });

--- a/tests/integration/components/pikaday-input-test.js
+++ b/tests/integration/components/pikaday-input-test.js
@@ -416,3 +416,17 @@ test('if maxDate is lower than value we set pikaday\'s current date to maxDate',
   this.set('maxDate', today);
   assert.equal(this.get('currentDate').getDate(), today.getDate(), 'value should change');
 });
+
+test('if value is null we don\'t enforce minDate or maxDate', function(assert) {
+  assert.expect(1);
+
+  let today = new Date();
+  let tomorrow = new Date( Date.now() + (60 * 60 * 24 * 1000));
+
+  this.set('currentDate', null);
+  this.render(hbs`{{pikaday-input maxDate=maxDate minDate=minDate value=currentDate onSelection=(action (mut currentDate)) }}`);
+
+  run(() => this.set('maxDate', tomorrow));
+  run(() => this.set('minDate', today));
+  assert.equal(this.get('currentDate'), null, 'value should be null');
+});


### PR DESCRIPTION
#121 introduced a new behaviour - datepicker value can't be cleared anymore (with null value) if minDate is set. I believe this was not intentional and that minDate should be enforced only if the value is set.

The code was checking `if (value < minDate)` to enforce the minDate but I guess the author forgot that `null < new Date()` evaluates to `true` (while `undefined < new Date()` is `false` as expeced).

Anyways, this PR fixes it. The provided test will fail if the code change is reverted.