### PR TITLE
Fix 2.12 deprecation of arguments in component life cycle hooks

### DIFF
--- a/addon/mixins/pikaday.js
+++ b/addon/mixins/pikaday.js
@@ -61,13 +61,13 @@ export default Ember.Mixin.create({
     };
   },
 
-  didUpdateAttrs({ newAttrs }) {
+  didUpdateAttrs() {
     this._super(...arguments);
     this.setMinDate();
     this.setMaxDate();
     this.setPikadayDate();
 
-    if(newAttrs.options) {
+    if (this.get('options')) {
       this._updateOptions();
     }
   },


### PR DESCRIPTION
Since Ember 2.12, arguments in certain component life cycle hooks, `didInitAttrs`,
`didReceiveAttrs`, and `didUpdateAttrs`, are deprecated. Deprecation ID:
EMBER-VIEWS.LIFECYCLE-HOOK-ARGUMENTS

See: http://emberjs.com/deprecations/v2.x/#toc_arguments-in-component-lifecycle-hooks