### PR TITLE
Allow binding of `autocomplete` attribute

### DIFF
--- a/addon/components/pikaday-input.js
+++ b/addon/components/pikaday-input.js
@@ -14,7 +14,8 @@ export default Ember.Component.extend(PikadayMixin, {
     'size',
     'required',
     'title',
-    'hidden'
+    'hidden',
+    'autocomplete'
   ],
 
   type: 'text',

--- a/tests/integration/components/pikaday-input-test.js
+++ b/tests/integration/components/pikaday-input-test.js
@@ -324,6 +324,15 @@ test('the input tag has the disabled attribute if it has been set on the compone
   assert.ok(this.$('input').is('[disabled]'));
 });
 
+test('the input tag has the autocomplete attribute if it has been set on the component', function(assert) {
+  this.render(hbs`{{pikaday-input autocomplete=autocomplete}}`);
+
+  assert.notOk(this.$('input').attr('autocomplete'));
+
+  this.set('autocomplete', 'off');
+  assert.equal(this.$('input').attr('autocomplete'), 'off');
+});
+
 test('using disabled prevent from opening pikaday', function(assert) {
   this.render(hbs`{{pikaday-input disabled=true}}`);
 


### PR DESCRIPTION
Small PR to allow binding the input's `autocomplete` attribute through the component. Added a simple test as well.