### PR TITLE
Fix ember-cli-node-asset deprecation of complex imports inline

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,15 +3,18 @@
 
 module.exports = {
   name: 'ember-pikaday',
-  
   options: {
     nodeAssets: {
       pikaday: {
-        import: [
-          { enabled: process.env.EMBER_CLI_FASTBOOT !== 'true', path: 'pikaday.js' },
-          'css/pikaday.css'
-        ]
+        vendor: ['pikaday.js', 'css/pikaday.css']
       }
+    }
+  },
+  included() {
+    this._super.included.apply(this, arguments);
+    if (!process.env.EMBER_CLI_FASTBOOT) {
+      this.import('vendor/pikaday/pikaday.js');
+      this.import('vendor/pikaday/css/pikaday.css');
     }
   }
 };

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ module.exports = {
     this._super.included.apply(this, arguments);
     if (!process.env.EMBER_CLI_FASTBOOT) {
       this.import('vendor/pikaday/pikaday.js');
-      this.import('vendor/pikaday/css/pikaday.css');
     }
+    this.import('vendor/pikaday/css/pikaday.css');
   }
 };


### PR DESCRIPTION
This is a new deprecation introduced by #143 because we upgraded ember-cli-node-assets from 0.1.4 to 0.2.2. Since 0.2.0, complex inline `import` has been deprecated, and we should use `vendor` instead and manually invoke `import()` in the `included` hook.

```
DEPRECATION: [ember-cli-node-assets] Defining complex imports inline is now deprecated. Instead, you can add the files to your `vendor` config for this package and import them explicitly. See the ember-cli-node-assets README for details.
```