### PR TITLE
#147 removing deprecation warning

### DIFF
--- a/addon/mixins/pikaday.js
+++ b/addon/mixins/pikaday.js
@@ -61,8 +61,13 @@ export default Ember.Mixin.create({
     };
   },
 
+	/**
+	 * When updating attrs, we need to reset some things in case they've changed.
+	 * @public
+	 * @memberOf {Mixins.Pikaday}
+	 * @return {undefined}
+	 */
   didUpdateAttrs() {
-    this._super(...arguments);
     this.setMinDate();
     this.setMaxDate();
     this.setPikadayDate();


### PR DESCRIPTION
Removing call to _super() since:

- #147 deprecation of attributes passed to this.
- we do not extend another component which needs to be called.