### PR TITLE
Need to run super on willDestroy

### DIFF
--- a/addon/mixins/pikaday.js
+++ b/addon/mixins/pikaday.js
@@ -92,6 +92,7 @@ export default Ember.Mixin.create({
   },
 
   willDestroyElement() {
+    this._super(...arguments);
     this.get('pikaday').destroy();
   },
 


### PR DESCRIPTION
This fixes the issue where when you delete and reinsert the element you get this error below

```

app-boot.js:15 Assertion Failed: You modified "concatenatedTriggerClasses" twice on <profiles@component:paper-autocomplete::ember2207> in a single render. It was rendered in "component:paper-autocomplete-trigger-container" and modified in "component:paper-button". This was unreliable and slow in Ember 1.x and is no longer supported. See https://github.com/emberjs/ember.js/issues/13948 for more details.
Error
    at assert (<anonymous>:27819:13)
    at assert (<anonymous>:39570:34)
    at Object.assertNotRendered (<anonymous>:45345:11)
    at propertyDidChange (<anonymous>:43961:30)
    at <anonymous>:44039:7
    at Meta._forEachIn (<anonymous>:41939:11)
    at Meta.forEachInDeps (<anonymous>:41909:19)
    at iterDeps (<anonymous>:44027:10)
    at dependentKeysDidChange (<anonymous>:44003:7)
    at propertyDidChange (<anonymous>:43943:9)
defaultDispatch @ app-boot.js:15
dispatchError @ app-boot.js:15
invokeWithOnError @ app-boot.js:15
flush @ app-boot.js:15
flush @ app-boot.js:15
end @ app-boot.js:15
run @ app-boot.js:15
join @ app-boot.js:15
run.join @ app-boot.js:15
(anonymous) @ app-boot.js:15
flaggedInstrument @ app-boot.js:15
handleEvent @ app-boot.js:15
exports.default._emberMetal.Mixin.create._Mixin$create.handleEvent @ app-boot.js:15
_bubbleEvent @ app-boot.js:15
(anonymous) @ app-boot.js:15
dispatch @ app-boot.js:15
elemData.handle @ app-boot.js:15
_super.bugsnag @ app-boot.js:15
```