### PR TITLE
Add ability to set a default date

### DIFF
--- a/addon/mixins/pikaday.js
+++ b/addon/mixins/pikaday.js
@@ -57,6 +57,8 @@ export default Ember.Mixin.create({
       yearRange: this.determineYearRange(),
       minDate: this.get('minDate') || null,
       maxDate: this.get('maxDate') || null,
+      defaultDate: this.get('defaultDate') || null,
+      setDefaultDate: !!this.get('defaultDate'),
       theme: this.get('theme') || null
     };
   },
@@ -86,6 +88,10 @@ export default Ember.Mixin.create({
 
   setupPikaday() {
     let pikaday = new Pikaday(this.get('_options'));
+
+    if (this.get('defaultDate')) {
+      this.set('value', this.get('defaultDate'));
+    }
 
     this.set('pikaday', pikaday);
     this.setPikadayDate();

--- a/tests/integration/components/pikaday-input-test.js
+++ b/tests/integration/components/pikaday-input-test.js
@@ -457,3 +457,29 @@ test('the original date passed to minDate or maxDate is not modified by pikaday'
   assert.equal(today.toISOString(), todayCopy.toISOString(), 'value should not change');
   assert.equal(tomorrow.toISOString(), tomorrowCopy.toISOString(), 'value should not change');
 });
+
+test('it sets the defaultDate', function(assert) {
+  assert.expect(1)
+
+  const today = new Date();
+
+  this.set('defaultDate', today)
+  this.render(hbs`{{pikaday-input defaultDate=defaultDate}}`)
+
+  assert.equal(this.get('defaultDate'), today)
+});
+
+test('it sets the initial date to the the defaultDate ', function(assert) {
+  assert.expect(3)
+
+  const date = new Date(2010, 7, 10);
+
+  this.set('defaultDate', date);
+  this.render(hbs`{{pikaday-input defaultDate=defaultDate}}`);
+
+  const interactor = openDatepicker(this.$('input'));
+
+  assert.equal(interactor.selectedYear(), 2010);
+  assert.equal(interactor.selectedMonth(), 7);
+  assert.equal(interactor.selectedDay(), 10);
+});


### PR DESCRIPTION
Add `defaultDate` as a native argument, and pass the appropriate
values through to `Pikaday`.

Fixes #117 