### PR TITLE
Fixes moment deprecation by using a date format

### DIFF
--- a/addon/mixins/pikaday.js
+++ b/addon/mixins/pikaday.js
@@ -124,7 +124,7 @@ export default Ember.Mixin.create({
 
       // If the current date is lower than minDate we set date to minDate
       run.schedule('sync', () => {
-        if (value && moment(value).isBefore(minDate, 'day')) {
+        if (value && moment(value, this.get('format')).isBefore(minDate, 'day')) {
           pikaday.setDate(minDate);
         }
       });


### PR DESCRIPTION
https://github.com/edgycircle/ember-pikaday/issues/156

Deprecation warning: value provided is not in a recognized RFC2822 or
ISO format. moment construction falls back to js Date(),
which is not reliable across all browsers and versions.
Non RFC2822/ISO date formats are discouraged and will be
removed in an upcoming major release