### PR TITLE
Prevent error in run later when component was destroyed

### DIFF
--- a/addon/mixins/pikaday.js
+++ b/addon/mixins/pikaday.js
@@ -71,6 +71,9 @@ export default Ember.Mixin.create({
 	 */
   didUpdateAttrs() {
     run.later(() => {
+      // Do not set or update anything when the component is destroying.
+      if (this.get('isDestroying') || this.get('isDestroyed')) { return; }
+
       this.setMinDate();
       this.setMaxDate();
       this.setPikadayDate();


### PR DESCRIPTION
Hi there,

i had some errors when the component received a update in the options but was destroying/destroyed in the run.later loop since it tries to set and update things.