### PR TITLE
Fix interactor day selection

### DIFF
--- a/addon/helpers/pikaday.js
+++ b/addon/helpers/pikaday.js
@@ -22,7 +22,7 @@ var PikadayInteractor = {
     $(this.selectorForMonthSelect).val(month);
     triggerNativeEvent($(this.selectorForMonthSelect)[0], 'change');
 
-    triggerNativeEvent($('td[data-day="' + day + '"] button:visible')[0], selectEvent);
+    triggerNativeEvent($('td[data-day="' + day + '"]:not(.is-outside-current-month) button:visible')[0], selectEvent);
   },
   selectedDay: function() {
     return $('.pika-single td.is-selected button').html();


### PR DESCRIPTION
 I believe there is a bug with the PikadayInteractor test helper if the  `showDaysInNextAndPreviousMonths` option is set to true.

**Example**: With `interactor.selectDate(new Date("Thu Jun 28 2018"))` the helper will select the _28th of May._
This is because the PikadayInteractor will 'click' on the first `td` element with that matches `$('td[data-day="' + day + '"] button:visible')`

However since the calender also display the last 4 days of the previous month, the interactor will choose the 28th of May.

This PR aims to fix this bug.

<img width="317" alt="image" src="https://user-images.githubusercontent.com/1991564/42033557-7fdce030-7add-11e8-81b3-23045ee3bccb.png">

